### PR TITLE
- Improve the help message for additional region handling

### DIFF
--- a/mash_client/cli.py
+++ b/mash_client/cli.py
@@ -230,7 +230,8 @@ def add_account():
 @click.option(
     '--additional-regions',
     is_flag=True,
-    help='Add additional regions that this account has access to.'
+    help=('Invoke region addition process to specify information '
+          'for additional regions')
 )
 @click.option(
     '--group',


### PR DESCRIPTION
  + The current message may mislead the user into specifying an additional
    region name. This in turn leads to a confusing error message.