### PR TITLE
Add comment to delete confirmation about updates.

### DIFF
--- a/mash_client/cli/account/azure.py
+++ b/mash_client/cli/account/azure.py
@@ -196,7 +196,9 @@ def list_azure_accounts(context):
     callback=abort_if_false,
     expose_value=False,
     help='Force deletion without prompt.',
-    prompt='Are you sure you want to delete account?'
+    prompt='Are you sure you want to delete account? '
+           'You can make account updates instead using '
+           '`mash account azure update`.'
 )
 @click.option(
     '--name',

--- a/mash_client/cli/account/ec2.py
+++ b/mash_client/cli/account/ec2.py
@@ -177,7 +177,9 @@ def list_ec2_accounts(context):
     callback=abort_if_false,
     expose_value=False,
     help='Force deletion without prompt.',
-    prompt='Are you sure you want to delete account?'
+    prompt='Are you sure you want to delete account? '
+           'You can make account updates instead using '
+           '`mash account ec2 update`.'
 )
 @click.option(
     '--name',

--- a/mash_client/cli/account/gce.py
+++ b/mash_client/cli/account/gce.py
@@ -170,7 +170,9 @@ def list_gce_accounts(context):
     callback=abort_if_false,
     expose_value=False,
     help='Force deletion without prompt.',
-    prompt='Are you sure you want to delete account?'
+    prompt='Are you sure you want to delete account? '
+           'You can make account updates instead using '
+           '`mash account gce update`.'
 )
 @click.option(
     '--name',


### PR DESCRIPTION
As there were not previously ways to update cloud accounts provide a helper message to inform users of the possibility for account updates instead of deleting an account.