### PR TITLE
Remove username

### DIFF
--- a/mash_client/cli/auth/__init__.py
+++ b/mash_client/cli/auth/__init__.py
@@ -46,22 +46,32 @@ def auth():
 
 @click.command()
 @click.option(
-    '--username',
+    '--email',
     type=click.STRING,
-    required=True,
-    help='The username for the mash user.'
+    help='The email for the mash user (default taken from config).'
 )
 @click.pass_context
-def login(context, username):
+def login(context, email):
     """
     Handle mash user login.
     """
     config_data = get_config(context.obj)
 
+    if not email:
+        email = config_data.get('email')
+
+    if not email:
+        echo_style(
+            'No --email parameter and no email in config.',
+            config_data['no_color'],
+            fg='red'
+        )
+        sys.exit(1)
+
     with handle_errors(config_data['log_level'], config_data['no_color']):
         password = click.prompt('Enter password', type=str, hide_input=True)
 
-        job_data = {'username': username, 'password': password}
+        job_data = {'email': email, 'password': password}
         tokens = handle_request(
             config_data,
             '/auth/login',

--- a/mash_client/cli/user.py
+++ b/mash_client/cli/user.py
@@ -25,6 +25,7 @@ import sys
 
 from mash_client.cli_utils import (
     get_config,
+    update_config,
     handle_errors,
     handle_request,
     handle_request_with_token,
@@ -43,19 +44,13 @@ def user():
 
 @click.command(name='create')
 @click.option(
-    '--username',
-    type=click.STRING,
-    required=True,
-    help='The username for the mash user.'
-)
-@click.option(
     '--email',
     type=click.STRING,
     required=True,
     help='The email address for the mash user.'
 )
 @click.pass_context
-def create_user(context, username, email):
+def create_user(context, email):
     """
     Handle mash user creation requests.
     """
@@ -68,7 +63,7 @@ def create_user(context, username, email):
         if pass1 != pass2:
             raise MashClientException('Passwords do not match!')
 
-        job_data = {'username': username, 'email': email, 'password': pass1}
+        job_data = {'email': email, 'password': pass1}
         result = handle_request(
             config_data,
             '/user/',
@@ -77,6 +72,9 @@ def create_user(context, username, email):
         )
 
         echo_dict(result, config_data['no_color'])
+
+        if result.get('id'):
+            update_config(context.obj, 'email', email)
 
 
 @click.command(name='info')

--- a/mash_client/cli_utils.py
+++ b/mash_client/cli_utils.py
@@ -96,6 +96,25 @@ def get_config(cli_context):
     return data
 
 
+def update_config(cli_context, key, value):
+    """
+    Update a key in the current config profile.
+    """
+    config_dir = cli_context['config_dir'] or default_config_dir
+    profile = cli_context['profile'] or default_profile
+    config_path = config_dir + profile + '.yaml'
+
+    config_values = {}
+    with suppress(Exception):
+        with open(config_path) as config_file:
+            config_values = yaml.safe_load(config_file)
+
+    config_values[key] = value
+
+    with open(config_path, 'w') as config_file:
+        yaml.dump(config_values, config_file, default_flow_style=False)
+
+
 @contextmanager
 def handle_errors(log_level, no_color):
     """

--- a/tests/data/default.yaml
+++ b/tests/data/default.yaml
@@ -1,3 +1,4 @@
+email: user1@fake.com
 host: http://127.0.0.1
 port: 5000
 verify: False

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -58,7 +58,7 @@ def test_auth_login(mock_requests):
     result = runner.invoke(
         main,
         [
-            '-C', 'tests/data/', 'auth', 'login', '--username', 'user1'
+            '-C', 'tests/data/', 'auth', 'login', '--email', 'user1@fake.com'
         ],
         input='secretpassword123\n'
     )

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -12,7 +12,6 @@ def test_user_create(mock_requests):
     response.status_code = 200
     response.json.return_value = {
         'id': '1',
-        'username': 'user1',
         'email': 'user1@fake.com'
     }
     mock_requests.post.return_value = response
@@ -21,8 +20,7 @@ def test_user_create(mock_requests):
     result = runner.invoke(
         main,
         [
-            '-C', 'tests/data/', 'user', 'create', '--username', 'user1',
-            '--email', 'user1@fake.com'
+            '-C', 'tests/data/', 'user', 'create', '--email', 'user1@fake.com'
         ],
         input='secretpassword\n'
               'secretpassword\n'
@@ -39,7 +37,6 @@ def test_user_info(mock_requests, mock_time):
     response.status_code = 200
     response.json.return_value = {
         'id': '1',
-        'username': 'user1',
         'email': 'user1@fake.com'
     }
     mock_requests.get.return_value = response


### PR DESCRIPTION
This removes username from MASH client. See https://github.com/SUSE-Enceladus/mash/pull/638 for server-side implementation.

For password based login, the email address is used. For convenience reasons, the default email address can be set in the profile configuration so the user won't have to type it at every login. `mash user create` automatically writes the email address to the profile config.