### PR TITLE
Add an example of groff usage in doc string.

### DIFF
--- a/mash_client/cli/job/gce.py
+++ b/mash_client/cli/job/gce.py
@@ -46,7 +46,18 @@ def gce():
 @click.pass_context
 def add(context, document):
     """
-    Send add gce job request to mash server based on provided json document.
+    Send add gce job request to mash server based on provided JSON document.
+
+    .SH JSON ARGUMENTS
+    .TP
+    \\fBbucket\\fP TEXT
+    Bucket where images will be stored.
+    .TP
+    \\fBcloud_account\\fP TEXT
+    Name of account credentials to use for job. [required]
+    .TP
+    \\fBcloud_architecture\\fP ENUM
+    Architecture of the image.  (x86_64, aarch64)
     """
     config_data = get_config(context.obj)
 


### PR DESCRIPTION
**Do not merge example only**

This will be used to add JSON arguments for the job add API. Man pages will then be auto generated with valid arguments.

The man page output for this looks like:

```
NAME
       mash-job-gce-add - Send add gce job request to mash server based...

SYNOPSIS
       mash job gce add [OPTIONS] DOCUMENT

DESCRIPTION
       Send add gce job request to mash server based on provided JSON document.

JSON ARGUMENTS
       bucket TEXT
              Bucket where images will be stored.

       cloud_account TEXT
              Name of account credentials to use for job. [required]

       cloud_architecture ENUM
              Architecture of the image.  (x86_64, aarch64)
```