### PR TITLE
Start adding API to retrieve job doc examples.

### DIFF
--- a/mash_client/cli/job/azure.py
+++ b/mash_client/cli/job/azure.py
@@ -27,7 +27,8 @@ from mash_client.cli_utils import (
     get_config,
     handle_errors,
     handle_request_with_token,
-    echo_dict
+    echo_dict,
+    get_job_schema_by_cloud
 )
 
 
@@ -62,4 +63,33 @@ def add(context, document):
         echo_dict(result, config_data['no_color'])
 
 
+@click.command(name='schema')
+@click.option(
+    '--json',
+    'output_style',
+    flag_value='json',
+    help='Prints an example json dictionary with example values.'
+)
+@click.option(
+    '--raw',
+    'output_style',
+    flag_value='raw',
+    help='Prints a raw jsonschema dictionary.'
+)
+@click.option(
+    '--annotated',
+    'output_style',
+    flag_value='annotated',
+    default=True,
+    help='Prints a raw jsonschema dictionary.'
+)
+@click.pass_context
+def get_schema(context, output_style):
+    """
+    Get the an annotated json dictionary for a Azure job.
+    """
+    get_job_schema_by_cloud(context, output_style, 'azure')
+
+
 azure.add_command(add)
+azure.add_command(get_schema)

--- a/mash_client/cli/job/ec2.py
+++ b/mash_client/cli/job/ec2.py
@@ -27,7 +27,8 @@ from mash_client.cli_utils import (
     get_config,
     handle_errors,
     handle_request_with_token,
-    echo_dict
+    echo_dict,
+    get_job_schema_by_cloud
 )
 
 
@@ -62,4 +63,33 @@ def add(context, document):
         echo_dict(result, config_data['no_color'])
 
 
+@click.command(name='schema')
+@click.option(
+    '--json',
+    'output_style',
+    flag_value='json',
+    help='Prints an example json dictionary with example values.'
+)
+@click.option(
+    '--raw',
+    'output_style',
+    flag_value='raw',
+    help='Prints a raw jsonschema dictionary.'
+)
+@click.option(
+    '--annotated',
+    'output_style',
+    flag_value='annotated',
+    default=True,
+    help='Prints a raw jsonschema dictionary.'
+)
+@click.pass_context
+def get_schema(context, output_style):
+    """
+    Get the an annotated json dictionary for a EC2 job.
+    """
+    get_job_schema_by_cloud(context, output_style, 'ec2')
+
+
 ec2.add_command(add)
+ec2.add_command(get_schema)

--- a/mash_client/cli/job/gce.py
+++ b/mash_client/cli/job/gce.py
@@ -27,7 +27,8 @@ from mash_client.cli_utils import (
     get_config,
     handle_errors,
     handle_request_with_token,
-    echo_dict
+    echo_dict,
+    get_job_schema_by_cloud
 )
 
 
@@ -62,4 +63,33 @@ def add(context, document):
         echo_dict(result, config_data['no_color'])
 
 
+@click.command(name='schema')
+@click.option(
+    '--json',
+    'output_style',
+    flag_value='json',
+    help='Prints an example json dictionary with example values.'
+)
+@click.option(
+    '--raw',
+    'output_style',
+    flag_value='raw',
+    help='Prints a raw jsonschema dictionary.'
+)
+@click.option(
+    '--annotated',
+    'output_style',
+    flag_value='annotated',
+    default=True,
+    help='Prints a raw jsonschema dictionary.'
+)
+@click.pass_context
+def get_schema(context, output_style):
+    """
+    Get the an annotated json dictionary for a GCE job.
+    """
+    get_job_schema_by_cloud(context, output_style, 'gce')
+
+
 gce.add_command(add)
+gce.add_command(get_schema)

--- a/mash_client/cli/job/oci.py
+++ b/mash_client/cli/job/oci.py
@@ -27,7 +27,8 @@ from mash_client.cli_utils import (
     get_config,
     handle_errors,
     handle_request_with_token,
-    echo_dict
+    echo_dict,
+    get_job_schema_by_cloud
 )
 
 
@@ -62,4 +63,33 @@ def add(context, document):
         echo_dict(result, config_data['no_color'])
 
 
+@click.command(name='schema')
+@click.option(
+    '--json',
+    'output_style',
+    flag_value='json',
+    help='Prints an example json dictionary with example values.'
+)
+@click.option(
+    '--raw',
+    'output_style',
+    flag_value='raw',
+    help='Prints a raw jsonschema dictionary.'
+)
+@click.option(
+    '--annotated',
+    'output_style',
+    flag_value='annotated',
+    default=True,
+    help='Prints a raw jsonschema dictionary.'
+)
+@click.pass_context
+def get_schema(context, output_style):
+    """
+    Get the an annotated json dictionary for a OCI job.
+    """
+    get_job_schema_by_cloud(context, output_style, 'oci')
+
+
 oci.add_command(add)
+oci.add_command(get_schema)

--- a/tests/test_azure_job.py
+++ b/tests/test_azure_job.py
@@ -1,7 +1,7 @@
+import json
+
 from unittest.mock import Mock, patch
-
 from mash_client.cli import main
-
 from click.testing import CliRunner
 
 
@@ -33,3 +33,41 @@ def test_job_add_azure(mock_requests, mock_time):
     )
     assert result.exit_code == 0
     assert '23fc826b-f6f5-4fbe-947d-52dcd097f0bc' in result.output
+
+
+@patch('mash_client.cli_utils.requests')
+def test_get_job_schema(mock_requests):
+    """Test mash job get annotated schema."""
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        'additionalProperties': False,
+        'properties': {
+            'cleanup_images': {
+                'example': True,
+                'type': 'boolean'
+            },
+            'cloud_account': {
+                'description': '',
+                'example': 'account1',
+                'minLength': 1,
+                'type': 'string'
+            }
+        },
+        'required': [
+            'cloud_account'
+        ],
+        'type': 'object'
+    }
+    mock_requests.get.return_value = response
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            '-C', 'tests/data/', 'job', 'oci', 'schema', '--annotated'
+        ]
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data['cloud_account']['example'] == 'account1'

--- a/tests/test_ec2_job.py
+++ b/tests/test_ec2_job.py
@@ -1,7 +1,7 @@
+import json
+
 from unittest.mock import Mock, patch
-
 from mash_client.cli import main
-
 from click.testing import CliRunner
 
 
@@ -60,3 +60,41 @@ def test_job_add_ec2(mock_requests, mock_time):
     )
     assert result.exit_code == 0
     assert '91b218d9-37c7-4638-9959-3259d77e3325' in result.output
+
+
+@patch('mash_client.cli_utils.requests')
+def test_get_job_schema(mock_requests):
+    """Test mash get raw job schema."""
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        'additionalProperties': False,
+        'properties': {
+            'cleanup_images': {
+                'example': True,
+                'type': 'boolean'
+            },
+            'cloud_account': {
+                'description': '',
+                'example': 'account1',
+                'minLength': 1,
+                'type': 'string'
+            }
+        },
+        'required': [
+            'cloud_account'
+        ],
+        'type': 'object'
+    }
+    mock_requests.get.return_value = response
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            '-C', 'tests/data/', 'job', 'oci', 'schema', '--raw'
+        ]
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data['additionalProperties'] is False

--- a/tests/test_gce_job.py
+++ b/tests/test_gce_job.py
@@ -1,7 +1,7 @@
+import json
+
 from unittest.mock import Mock, patch
-
 from mash_client.cli import main
-
 from click.testing import CliRunner
 
 
@@ -33,3 +33,41 @@ def test_job_add_gce(mock_requests, mock_time):
     )
     assert result.exit_code == 0
     assert '23fc826b-f6f5-4fbe-947d-52dcd097f0bc' in result.output
+
+
+@patch('mash_client.cli_utils.requests')
+def test_get_job_schema(mock_requests):
+    """Test mash job get json template schema."""
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        'additionalProperties': False,
+        'properties': {
+            'cleanup_images': {
+                'example': True,
+                'type': 'boolean'
+            },
+            'cloud_account': {
+                'description': '',
+                'example': 'account1',
+                'minLength': 1,
+                'type': 'string'
+            }
+        },
+        'required': [
+            'cloud_account'
+        ],
+        'type': 'object'
+    }
+    mock_requests.get.return_value = response
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            '-C', 'tests/data/', 'job', 'oci', 'schema', '--json'
+        ]
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data['cloud_account'] == ''

--- a/tests/test_oci_job.py
+++ b/tests/test_oci_job.py
@@ -1,7 +1,7 @@
+import json
+
 from unittest.mock import Mock, patch
-
 from mash_client.cli import main
-
 from click.testing import CliRunner
 
 
@@ -33,3 +33,41 @@ def test_job_add_oci(mock_requests, mock_time):
     )
     assert result.exit_code == 0
     assert '23fc826b-f6f5-4fbe-947d-52dcd097f0bc' in result.output
+
+
+@patch('mash_client.cli_utils.requests')
+def test_get_job_schema(mock_requests):
+    """Test mash get default schema."""
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        'additionalProperties': False,
+        'properties': {
+            'cleanup_images': {
+                'example': True,
+                'type': 'boolean'
+            },
+            'cloud_account': {
+                'description': '',
+                'example': 'account1',
+                'minLength': 1,
+                'type': 'string'
+            }
+        },
+        'required': [
+            'cloud_account'
+        ],
+        'type': 'object'
+    }
+    mock_requests.get.return_value = response
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            '-C', 'tests/data/', 'job', 'oci', 'schema'
+        ]
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data['cloud_account']['type'] == 'string'


### PR DESCRIPTION
The three possible outputs here look like:

annotated (default):

```
{
    "bucket": {
        "description": "",
        "example": "images",
        "type": "string"
    },
    "cleanup_images": {
        "example": true,
        "type": "boolean"
    },
    "cloud_account": {
        "description": "",
        "example": "account1",
        "type": "string",
        "required": true
    },
    "cloud_architecture": {
        "enum": [
            "x86_64",
            "aarch64"
        ],
        "example": "x86_64",
        "type": "string"
    },
    "cloud_image_name": {
        "description": "",
        "example": "opensuse-leap-15-v{date}",
        "type": "string",
        "required": true
    }
}
```

raw:

```
{
    "additionalProperties": false,
    "properties": {
        "bucket": {
            "description": "",
            "example": "images",
            "minLength": 1,
            "type": "string"
        },
        "cleanup_images": {
            "example": true,
            "type": "boolean"
        },
        "cloud_account": {
            "description": "",
            "example": "account1",
            "minLength": 1,
            "type": "string"
        },
        "cloud_architecture": {
            "enum": [
                "x86_64",
                "aarch64"
            ],
            "example": "x86_64",
            "type": "string"
        },
        "cloud_image_name": {
            "description": "",
            "example": "opensuse-leap-15-v{date}",
            "minLength": 1,
            "type": "string"
        }
    },
    "required": [
        "last_service",
        "utctime",
        "image",
        "cloud_image_name",
        "image_description",
        "download_url",
        "cloud_account"
    ],
    "type": "object"
}
```

json:

```
{
    "bucket": "",
    "cleanup_images": null,
    "cloud_account": "",
    "cloud_architecture": "",
    "cloud_image_name": "",
}
```

How do these look? Any suggestions? I know Robert mentioned concern of having a filled in (example values) json but I think it's safe as a secondary option with the default being the annotated version. The other possibility for the json option is that it could return an empty json dictionary (no values) but this would be difficult with certain types like integer and boolean which don't have a base None value like strings `''` and lists `[]`.