### PR TITLE
Cleanup group options in azure and gce accounts.

### DIFF
--- a/mash_client/cli/account/azure.py
+++ b/mash_client/cli/account/azure.py
@@ -43,11 +43,6 @@ def azure():
 
 @click.command()
 @click.option(
-    '--group',
-    type=click.STRING,
-    help='Group name to associate the account with.'
-)
-@click.option(
     '--name',
     type=click.STRING,
     required=True,
@@ -109,7 +104,7 @@ def azure():
 )
 @click.pass_context
 def add(
-    context, group, name, region, source_container,
+    context, name, region, source_container,
     source_resource_group, source_storage_account,
     destination_container, destination_resource_group,
     destination_storage_account, credentials
@@ -134,9 +129,6 @@ def add(
             'destination_resource_group': destination_resource_group,
             'destination_storage_account': destination_storage_account
         }
-
-        if group:
-            data['group'] = group
 
         result = handle_request_with_token(
             config_data,

--- a/mash_client/cli/account/gce.py
+++ b/mash_client/cli/account/gce.py
@@ -43,11 +43,6 @@ def gce():
 
 @click.command()
 @click.option(
-    '--group',
-    type=click.STRING,
-    help='Group name to associate account with.'
-)
-@click.option(
     '--name',
     type=click.STRING,
     required=True,
@@ -84,7 +79,7 @@ def gce():
 )
 @click.pass_context
 def add(
-    context, group, name, bucket, zone, testing_account,
+    context, name, bucket, zone, testing_account,
     is_publishing_account, credentials
 ):
     """
@@ -102,9 +97,6 @@ def add(
             'credentials': creds,
             'region': zone
         }
-
-        if group:
-            data['group'] = group
 
         if testing_account:
             data['testing_account'] = testing_account


### PR DESCRIPTION
These are not valid options anymore for Azure or GCE and would cause a validation error from the server.