### PR TITLE
Handle errors from OIDC provider

### DIFF
--- a/mash_client/cli/auth/__init__.py
+++ b/mash_client/cli/auth/__init__.py
@@ -156,6 +156,7 @@ def oidc(context):
             '{}: {}'.format(result['msg'], auth_url),
             config_data['no_color']
         )
+        click.launch(auth_url)
 
         auth_code = get_oauth2_code(redirect_port)
 

--- a/mash_client/cli/auth/__init__.py
+++ b/mash_client/cli/auth/__init__.py
@@ -159,6 +159,14 @@ def oidc(context):
 
         auth_code = get_oauth2_code(redirect_port)
 
+        if not auth_code:
+            echo_style(
+                'Failed login: No authentication code received.',
+                config_data['no_color'],
+                fg='red'
+            )
+            sys.exit(1)
+
         job_data = {
             'auth_code': auth_code,
             'state': result['state'],

--- a/mash_client/cli_utils.py
+++ b/mash_client/cli_utils.py
@@ -375,7 +375,10 @@ class RequestHandler(BaseHTTPRequestHandler):
 
         exception = CodeReceivedException(params.get('code', [None])[0])
         self.wfile.write(bytes(
-            '<html><body><h1>{}</h1></body></html>'.format(msg), 'utf-8'
+            '<html><body><div style="background-color:#FF8E77;width:50%;'
+            'margin:auto;padding:10px;border-radius:10px;text-align:center;">'
+            '<h3>{}</h3></div></body></html>'.format(msg),
+            'utf-8'
         ))
         raise exception
 

--- a/mash_client/cli_utils.py
+++ b/mash_client/cli_utils.py
@@ -364,11 +364,16 @@ class RequestHandler(BaseHTTPRequestHandler):
         self.end_headers()
         params = parse_qs(urlparse(self.path).query)
         if not params.get('code'):
-            msg = 'ERROR: No authentication code received.'
-            exception = Exception(msg)
+            if params.get('error_description', []):
+                msg = params['error_description'][0]
+            else:
+                msg = 'ERROR: No authentication code received.'
+
+            msg += ' Ensure you have added the Mash app to your Okta account.'
         else:
             msg = 'Authentication code received. You may close this tab.'
-            exception = CodeReceivedException(params['code'][0])
+
+        exception = CodeReceivedException(params.get('code', [None])[0])
         self.wfile.write(bytes(
             '<html><body><h1>{}</h1></body></html>'.format(msg), 'utf-8'
         ))

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -86,6 +86,7 @@ def test_auth_logout(mock_requests):
     assert 'Logout successful' in result.output
 
 
+@patch('click.launch')
 @patch('mash_client.cli_utils.HTTPServer')
 @patch('mash_client.cli_utils.socket.gethostbyname')
 @patch('mash_client.cli_utils.socket.socket')
@@ -94,7 +95,8 @@ def test_auth_oidc(
     mock_requests,
     mock_socket,
     mock_gethostbyname,
-    mock_http_server
+    mock_http_server,
+    mock_click_launch
 ):
     """Test mash auth oidc."""
     response_get = Mock()

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -34,6 +34,7 @@ from mash_client.cli_utils import CodeReceivedException
 @patch.object(RequestHandler, '__init__', lambda x: None)
 def test_request_handler(mock_send_header, mock_send_response, mock_end_hdrs):
     code = '0123456789ABCDEF'
+    description = 'User+is+not+assigned+to+the+client+application.'
 
     rh = RequestHandler()
     setattr(rh, 'wfile', Mock())
@@ -48,11 +49,11 @@ def test_request_handler(mock_send_header, mock_send_response, mock_end_hdrs):
 
     mock_send_response.reset_mock()
     mock_send_header.reset_mock()
-    rh.path = 'http://localhost:9000/?nocode'
+    rh.path = 'http://localhost:9000/?error_description={}'.format(description)
 
-    with raises(Exception) as e:
+    with raises(CodeReceivedException) as e:
         rh.do_GET()
 
-    assert(str(e.value) == 'ERROR: No authentication code received.')
+    assert e.value.code is None
     mock_send_response.assert_called_once_with(200)
     mock_send_header.assert_called_once_with('Content-type', 'text/html')


### PR DESCRIPTION
Base exceptions get caught and handled by the BaseHTTPRequestHandler so raise custom exception with None as code to ensure the server is closed on failure. Provide error description to user and additional note on adding mash to Okta account.

Use click launch function to open browser.

And spruce up the HTML output.