### PR TITLE
Add option for job dry run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.7"
 install:
   - pip install -e .[dev]
+  - pip install --upgrade pytest
 script:
   - pytest --cov=mash_client
   - flake8

--- a/mash_client/cli/job/azure.py
+++ b/mash_client/cli/job/azure.py
@@ -2,7 +2,7 @@
 
 """mash client CLI Azure job endpoints using click library."""
 
-# Copyright (c) 2019 SUSE LLC. All rights reserved.
+# Copyright (c) 2020 SUSE LLC. All rights reserved.
 #
 # This file is part of mash_client. mash_client provides a command line
 # utility for interfacing with a MASH server.
@@ -28,6 +28,7 @@ from mash_client.cli_utils import (
     handle_errors,
     handle_request_with_token,
     echo_dict,
+    echo_style,
     get_job_schema_by_cloud
 )
 
@@ -40,12 +41,17 @@ def azure():
 
 
 @click.command()
+@click.option(
+    '--dry-run',
+    is_flag=True,
+    help='Validate job document but do not create job.'
+)
 @click.argument(
     'document',
     type=click.Path(exists=True)
 )
 @click.pass_context
-def add(context, document):
+def add(context, dry_run, document):
     """
     Send add azure job request to mash server based on provided json document.
     """
@@ -55,12 +61,19 @@ def add(context, document):
         with open(document) as job_file:
             job_data = json.load(job_file)
 
+        if dry_run:
+            job_data['dry_run'] = True
+
         result = handle_request_with_token(
             config_data,
             '/jobs/azure/',
             job_data
         )
-        echo_dict(result, config_data['no_color'])
+
+        if 'msg' in result:
+            echo_style(result['msg'], config_data['no_color'])
+        else:
+            echo_dict(result, config_data['no_color'])
 
 
 @click.command(name='schema')

--- a/mash_client/cli/job/ec2.py
+++ b/mash_client/cli/job/ec2.py
@@ -2,7 +2,7 @@
 
 """mash client CLI ec2 job endpoints using click library."""
 
-# Copyright (c) 2019 SUSE LLC. All rights reserved.
+# Copyright (c) 2020 SUSE LLC. All rights reserved.
 #
 # This file is part of mash_client. mash_client provides a command line
 # utility for interfacing with a MASH server.
@@ -28,6 +28,7 @@ from mash_client.cli_utils import (
     handle_errors,
     handle_request_with_token,
     echo_dict,
+    echo_style,
     get_job_schema_by_cloud
 )
 
@@ -40,12 +41,17 @@ def ec2():
 
 
 @click.command()
+@click.option(
+    '--dry-run',
+    is_flag=True,
+    help='Validate job document but do not create job.'
+)
 @click.argument(
     'document',
     type=click.Path(exists=True)
 )
 @click.pass_context
-def add(context, document):
+def add(context, dry_run, document):
     """
     Send add ec2 job request to mash server based on provided json document.
     """
@@ -55,12 +61,19 @@ def add(context, document):
         with open(document) as job_file:
             job_data = json.load(job_file)
 
+        if dry_run:
+            job_data['dry_run'] = True
+
         result = handle_request_with_token(
             config_data,
             '/jobs/ec2/',
             job_data
         )
-        echo_dict(result, config_data['no_color'])
+
+        if 'msg' in result:
+            echo_style(result['msg'], config_data['no_color'])
+        else:
+            echo_dict(result, config_data['no_color'])
 
 
 @click.command(name='schema')

--- a/mash_client/cli/job/gce.py
+++ b/mash_client/cli/job/gce.py
@@ -2,7 +2,7 @@
 
 """mash client CLI gce job endpoints using click library."""
 
-# Copyright (c) 2019 SUSE LLC. All rights reserved.
+# Copyright (c) 2020 SUSE LLC. All rights reserved.
 #
 # This file is part of mash_client. mash_client provides a command line
 # utility for interfacing with a MASH server.
@@ -28,6 +28,7 @@ from mash_client.cli_utils import (
     handle_errors,
     handle_request_with_token,
     echo_dict,
+    echo_style,
     get_job_schema_by_cloud
 )
 
@@ -40,12 +41,17 @@ def gce():
 
 
 @click.command()
+@click.option(
+    '--dry-run',
+    is_flag=True,
+    help='Validate job document but do not create job.'
+)
 @click.argument(
     'document',
     type=click.Path(exists=True)
 )
 @click.pass_context
-def add(context, document):
+def add(context, dry_run, document):
     """
     Send add gce job request to mash server based on provided json document.
     """
@@ -55,12 +61,19 @@ def add(context, document):
         with open(document) as job_file:
             job_data = json.load(job_file)
 
+        if dry_run:
+            job_data['dry_run'] = True
+
         result = handle_request_with_token(
             config_data,
             '/jobs/gce/',
             job_data
         )
-        echo_dict(result, config_data['no_color'])
+
+        if 'msg' in result:
+            echo_style(result['msg'], config_data['no_color'])
+        else:
+            echo_dict(result, config_data['no_color'])
 
 
 @click.command(name='schema')

--- a/mash_client/cli/job/oci.py
+++ b/mash_client/cli/job/oci.py
@@ -28,6 +28,7 @@ from mash_client.cli_utils import (
     handle_errors,
     handle_request_with_token,
     echo_dict,
+    echo_style,
     get_job_schema_by_cloud
 )
 
@@ -40,12 +41,17 @@ def oci():
 
 
 @click.command()
+@click.option(
+    '--dry-run',
+    is_flag=True,
+    help='Validate job document but do not create job.'
+)
 @click.argument(
     'document',
     type=click.Path(exists=True)
 )
 @click.pass_context
-def add(context, document):
+def add(context, dry_run, document):
     """
     Send add oci job request to mash server based on provided json document.
     """
@@ -55,12 +61,19 @@ def add(context, document):
         with open(document) as job_file:
             job_data = json.load(job_file)
 
+        if dry_run:
+            job_data['dry_run'] = True
+
         result = handle_request_with_token(
             config_data,
             '/jobs/oci/',
             job_data
         )
-        echo_dict(result, config_data['no_color'])
+
+        if 'msg' in result:
+            echo_style(result['msg'], config_data['no_color'])
+        else:
+            echo_dict(result, config_data['no_color'])
 
 
 @click.command(name='schema')


### PR DESCRIPTION
If dry run flag is set the validation on the job doc will happen server side but no job will be created.

Related to https://github.com/SUSE-Enceladus/mash/pull/669.