### PR TITLE
OIDC: Fix potential 'no redirect port available' error.

### DIFF
--- a/mash_client/cli_utils.py
+++ b/mash_client/cli_utils.py
@@ -340,6 +340,7 @@ def additional_regions_repl():
 
 def get_free_port(ports):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     local_addr = socket.gethostbyname('localhost')
     for port in ports:
         try:


### PR DESCRIPTION
Set SO_REUSEADDR when probing for available ports. The socket is not released immediately by the kernel so if there was a previous OIDC auth attempt briefly before the current one, the port may be reported as already in use even though it is availabe.