### PR TITLE
Add API commands for job status

### DIFF
--- a/mash_client/cli/job/__init__.py
+++ b/mash_client/cli/job/__init__.py
@@ -137,15 +137,22 @@ def status(context, job_id):
     required=True,
     help='The UUID of the job to wait for a finished state.'
 )
+@click.option(
+    '-t',
+    '--wait-time',
+    type=click.IntRange(min=60),
+    default=300,
+    help='The time to wait before checking job status again (seconds).'
+)
 @click.pass_context
-def wait(context, job_id):
+def wait(context, wait_time, job_id):
     """
-    Get basic status for a job in the MASH server pipeline.
+    Wait for job to arrive at finished or failed status.
+
+    By default waits 5 minutes between status queries.
     """
     config_data = get_config(context.obj)
-
     state = 'undefined'
-    wait = 1
 
     while True:
         with handle_errors(config_data['log_level'], config_data['no_color']):
@@ -160,8 +167,7 @@ def wait(context, job_id):
         if state not in ('running', 'undefined'):
             break
 
-        time.sleep(wait)
-        wait *= 2
+        time.sleep(wait_time)
 
     click.echo(state)
 

--- a/mash_client/cli/job/__init__.py
+++ b/mash_client/cli/job/__init__.py
@@ -22,6 +22,8 @@
 
 import click
 
+from contextlib import suppress
+
 from mash_client.cli_utils import (
     get_config,
     handle_errors,
@@ -64,6 +66,11 @@ def list_jobs(context):
 
 @click.command(name='info')
 @click.option(
+    '--show-data',
+    is_flag=True,
+    help='Include all status info for the job.'
+)
+@click.option(
     '--job-id',
     type=click.UUID,
     required=True,
@@ -71,7 +78,7 @@ def list_jobs(context):
          'from the MASH server pipeline.'
 )
 @click.pass_context
-def get(context, job_id):
+def get(context, job_id, show_data):
     """
     Get info for a job in the MASH server pipeline.
     """
@@ -83,6 +90,10 @@ def get(context, job_id):
             '/jobs/{0}'.format(job_id),
             action='get'
         )
+
+        if not show_data:
+            with suppress(KeyError):
+                del result['data']
 
         echo_dict(result, config_data['no_color'])
 

--- a/mash_client/cli/job/__init__.py
+++ b/mash_client/cli/job/__init__.py
@@ -78,8 +78,7 @@ def list_jobs(context):
     '--job-id',
     type=click.UUID,
     required=True,
-    help='The UUID of the job to be removed '
-         'from the MASH server pipeline.'
+    help='The UUID of the job to retrieve.'
 )
 @click.pass_context
 def get(context, job_id, show_data):
@@ -107,8 +106,7 @@ def get(context, job_id, show_data):
     '--job-id',
     type=click.UUID,
     required=True,
-    help='The UUID of the job to be removed '
-         'from the MASH server pipeline.'
+    help='The UUID of the job for the status query.'
 )
 @click.pass_context
 def status(context, job_id):
@@ -137,8 +135,7 @@ def status(context, job_id):
     '--job-id',
     type=click.UUID,
     required=True,
-    help='The UUID of the job to be removed '
-         'from the MASH server pipeline.'
+    help='The UUID of the job to wait for a finished state.'
 )
 @click.pass_context
 def wait(context, job_id):
@@ -181,8 +178,7 @@ def wait(context, job_id):
     '--job-id',
     type=click.UUID,
     required=True,
-    help='The UUID of the job to be removed '
-         'from the MASH server pipeline.'
+    help='The UUID of the job for test results query.'
 )
 @click.pass_context
 def test_results(context, job_id, verbose):

--- a/mash_client/cli/job/__init__.py
+++ b/mash_client/cli/job/__init__.py
@@ -21,6 +21,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import click
+import json
+import sys
 
 from contextlib import suppress
 
@@ -30,7 +32,8 @@ from mash_client.cli_utils import (
     handle_request_with_token,
     abort_if_false,
     echo_dict,
-    echo_style
+    echo_style,
+    echo_results
 )
 
 from mash_client.cli.job.azure import azure
@@ -100,6 +103,128 @@ def get(context, job_id, show_data):
 
 @click.command()
 @click.option(
+    '--job-id',
+    type=click.UUID,
+    required=True,
+    help='The UUID of the job to be removed '
+         'from the MASH server pipeline.'
+)
+@click.pass_context
+def status(context, job_id):
+    """
+    Get basic status for a job in the MASH server pipeline.
+    """
+    config_data = get_config(context.obj)
+
+    with handle_errors(config_data['log_level'], config_data['no_color']):
+        result = handle_request_with_token(
+            config_data,
+            '/jobs/{0}'.format(job_id),
+            action='get'
+        )
+
+        status_info = {'state': result['state']}
+
+        if result['state'] == 'running' and 'current_service' in result:
+            status_info['current_service'] = result['current_service']
+
+        echo_dict(status_info, config_data['no_color'])
+
+
+@click.command()
+@click.option(
+    '--job-id',
+    type=click.UUID,
+    required=True,
+    help='The UUID of the job to be removed '
+         'from the MASH server pipeline.'
+)
+@click.pass_context
+def wait(context, job_id):
+    """
+    Get basic status for a job in the MASH server pipeline.
+    """
+    config_data = get_config(context.obj)
+
+    state = 'undefined'
+    while state in ('running', 'undefined'):
+        with handle_errors(config_data['log_level'], config_data['no_color']):
+            result = handle_request_with_token(
+                config_data,
+                '/jobs/{0}'.format(job_id),
+                action='get'
+            )
+
+        state = result['state']
+
+    click.echo(state)
+
+
+@click.command(name='test-results')
+@click.option(
+    '-v',
+    '--verbose',
+    is_flag=True,
+    help='Display each test and subsequent result. '
+         'By default only the summary is displayed.'
+)
+@click.option(
+    '--job-id',
+    type=click.UUID,
+    required=True,
+    help='The UUID of the job to be removed '
+         'from the MASH server pipeline.'
+)
+@click.pass_context
+def test_results(context, job_id, verbose):
+    """
+    Display test results for a job in the MASH server pipeline.
+    """
+    config_data = get_config(context.obj)
+
+    with handle_errors(config_data['log_level'], config_data['no_color']):
+        result = handle_request_with_token(
+            config_data,
+            '/jobs/{0}'.format(job_id),
+            action='get'
+        )
+
+        if 'data' not in result:
+            click.secho(
+                'The job has no status data, cannot provide test results.',
+                fg='red'
+            )
+            sys.exit(1)
+
+        if 'test_results' not in result['data']:
+            click.secho(
+                'The job has no test results.',
+                fg='red'
+            )
+            sys.exit(1)
+
+        try:
+            result_data = json.loads(
+                result['data']['test_results'].replace('\'', '"')
+            )
+        except Exception:
+            click.secho(
+                'The job\'s test results are malformed, the data can be '
+                'viewed using '
+                '"mash job info --job-id {job_id} --show-data".',
+                fg='red'
+            )
+            sys.exit(1)
+
+        echo_results(
+            result_data,
+            config_data['no_color'],
+            verbose
+        )
+
+
+@click.command()
+@click.option(
     '--force',
     is_flag=True,
     callback=abort_if_false,
@@ -134,6 +259,9 @@ def delete(context, job_id):
 job.add_command(delete)
 job.add_command(get)
 job.add_command(list_jobs)
+job.add_command(status)
+job.add_command(wait)
+job.add_command(test_results)
 
 job.add_command(azure)
 job.add_command(ec2)

--- a/mash_client/cli/job/__init__.py
+++ b/mash_client/cli/job/__init__.py
@@ -23,6 +23,7 @@
 import click
 import json
 import sys
+import time
 
 from contextlib import suppress
 
@@ -147,7 +148,9 @@ def wait(context, job_id):
     config_data = get_config(context.obj)
 
     state = 'undefined'
-    while state in ('running', 'undefined'):
+    wait = 1
+
+    while True:
         with handle_errors(config_data['log_level'], config_data['no_color']):
             result = handle_request_with_token(
                 config_data,
@@ -156,6 +159,12 @@ def wait(context, job_id):
             )
 
         state = result['state']
+
+        if state not in ('running', 'undefined'):
+            break
+
+        time.sleep(wait)
+        wait *= 2
 
     click.echo(state)
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,8 +1,38 @@
+import json
+
 from unittest.mock import Mock, patch
 
 from mash_client.cli import main
 
 from click.testing import CliRunner
+
+
+test_results = {
+    "summary": {
+        "duration": 1.618,
+        "num_tests": 3,
+        "passed": 1,
+        "skipped": 1,
+        "failed": 1
+    },
+    'tests': [
+        {
+            'name': 'test_soft_reboot',
+            'outcome': 'failed',
+            'test_index': 0
+        },
+        {
+            'name': 'test_sles_motd.py::test_sles_motd',
+            'outcome': 'passed',
+            'test_index': 1
+        },
+        {
+            'name': 'test_sles_license.py::test_sles_license',
+            'outcome': 'skipped',
+            'test_index': 2
+        }
+    ]
+}
 
 
 @patch('mash_client.cli_utils.time')
@@ -55,6 +85,106 @@ def test_job_info(mock_requests, mock_time):
     )
     assert result.exit_code == 0
     assert '23fc826b-f6f5-4fbe-947d-52dcd097f0bc' in result.output
+
+
+@patch('mash_client.cli_utils.time')
+@patch('mash_client.cli_utils.requests')
+def test_job_wait(mock_requests, mock_time):
+    """Test mash job get info."""
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        'job_id': '23fc826b-f6f5-4fbe-947d-52dcd097f0bc',
+        'last_service': 'deprecation',
+        'utctime': 'now',
+        'image': 'test_image_oem',
+        'download_url':
+            'http://download.opensuse.org/repositories/Cloud:Tools/images',
+        'cloud_architecture': 'x86_64',
+        'state': 'finished'
+    }
+    mock_requests.get.return_value = response
+    mock_time.time.return_value = 1568150480
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            '-C', 'tests/data/', 'job', 'wait',
+            '--job-id', '23fc826b-f6f5-4fbe-947d-52dcd097f0bc'
+        ]
+    )
+    assert result.exit_code == 0
+    assert 'finished' in result.output
+
+
+@patch('mash_client.cli_utils.time')
+@patch('mash_client.cli_utils.requests')
+def test_job_status(mock_requests, mock_time):
+    """Test mash job get info."""
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        'job_id': '23fc826b-f6f5-4fbe-947d-52dcd097f0bc',
+        'last_service': 'deprecation',
+        'utctime': 'now',
+        'image': 'test_image_oem',
+        'download_url':
+            'http://download.opensuse.org/repositories/Cloud:Tools/images',
+        'cloud_architecture': 'x86_64',
+        'state': 'running',
+        'current_service': 'test'
+    }
+    mock_requests.get.return_value = response
+    mock_time.time.return_value = 1568150480
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            '-C', 'tests/data/', 'job', 'status',
+            '--job-id', '23fc826b-f6f5-4fbe-947d-52dcd097f0bc'
+        ]
+    )
+    assert result.exit_code == 0
+    assert 'running' in result.output
+    assert 'test' in result.output
+
+
+@patch('mash_client.cli_utils.time')
+@patch('mash_client.cli_utils.requests')
+def test_job_test_results(mock_requests, mock_time):
+    """Test mash job get info."""
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        'job_id': '23fc826b-f6f5-4fbe-947d-52dcd097f0bc',
+        'last_service': 'deprecation',
+        'utctime': 'now',
+        'image': 'test_image_oem',
+        'download_url':
+            'http://download.opensuse.org/repositories/Cloud:Tools/images',
+        'cloud_architecture': 'x86_64',
+        'state': 'finished',
+        'data': {
+            'test_results': json.dumps(test_results)
+        }
+    }
+    mock_requests.get.return_value = response
+    mock_time.time.return_value = 1568150480
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            '-C', 'tests/data/', 'job', 'test-results',
+            '--job-id', '23fc826b-f6f5-4fbe-947d-52dcd097f0bc',
+            '--verbose'
+        ]
+    )
+    assert result.exit_code == 0
+    assert 'FAILED tests=3|pass=1|skip=1|fail=1|error=0' in result.output
+    assert 'test_sles_license' in result.output
 
 
 @patch('mash_client.cli_utils.time')


### PR DESCRIPTION
- Add a flag to display status data. By default do not show the data key. This key can be very busy so make it optional.
- Add commands to list basic status, wait on job status to be in finished (or failed) state and to display test results.