### PR TITLE
Add helper functions for client use as SDK

### DIFF
--- a/mash_client/cli/auth/__init__.py
+++ b/mash_client/cli/auth/__init__.py
@@ -71,8 +71,8 @@ def login(context, email):
 
     with handle_errors(config_data['log_level'], config_data['no_color']):
         password = click.prompt('Enter password', type=str, hide_input=True)
-        login_with_pass(config_data, email, password)
-        echo_style('Login successful.', config_data['no_color'])
+        result = login_with_pass(config_data, email, password)
+        echo_style(result['msg'], config_data['no_color'])
 
 
 @click.command()

--- a/mash_client/cli/job/azure.py
+++ b/mash_client/cli/job/azure.py
@@ -26,11 +26,10 @@ import json
 from mash_client.cli_utils import (
     get_config,
     handle_errors,
-    handle_request_with_token,
     echo_dict,
     echo_style
 )
-from mash_client.controller import get_job_schema_by_cloud
+from mash_client.controller import get_job_schema_by_cloud, add_job
 
 
 @click.group()
@@ -64,11 +63,7 @@ def add(context, dry_run, document):
         if dry_run:
             job_data['dry_run'] = True
 
-        result = handle_request_with_token(
-            config_data,
-            '/jobs/azure/',
-            job_data
-        )
+        result = add_job(config_data, job_data, 'azure')
 
         if 'msg' in result:
             echo_style(result['msg'], config_data['no_color'])

--- a/mash_client/cli/job/azure.py
+++ b/mash_client/cli/job/azure.py
@@ -28,9 +28,9 @@ from mash_client.cli_utils import (
     handle_errors,
     handle_request_with_token,
     echo_dict,
-    echo_style,
-    get_job_schema_by_cloud
+    echo_style
 )
+from mash_client.controller import get_job_schema_by_cloud
 
 
 @click.group()

--- a/mash_client/cli/job/azure.py
+++ b/mash_client/cli/job/azure.py
@@ -101,7 +101,12 @@ def get_schema(context, output_style):
     """
     Get the an annotated json dictionary for a Azure job.
     """
-    get_job_schema_by_cloud(context, output_style, 'azure')
+    config_data = get_config(context.obj)
+
+    with handle_errors(config_data['log_level'], config_data['no_color']):
+        result = get_job_schema_by_cloud(config_data, output_style, 'azure')
+
+    echo_dict(result, config_data['no_color'])
 
 
 azure.add_command(add)

--- a/mash_client/cli/job/ec2.py
+++ b/mash_client/cli/job/ec2.py
@@ -28,9 +28,9 @@ from mash_client.cli_utils import (
     handle_errors,
     handle_request_with_token,
     echo_dict,
-    echo_style,
-    get_job_schema_by_cloud
+    echo_style
 )
+from mash_client.controller import get_job_schema_by_cloud
 
 
 @click.group()

--- a/mash_client/cli/job/ec2.py
+++ b/mash_client/cli/job/ec2.py
@@ -26,11 +26,10 @@ import json
 from mash_client.cli_utils import (
     get_config,
     handle_errors,
-    handle_request_with_token,
     echo_dict,
     echo_style
 )
-from mash_client.controller import get_job_schema_by_cloud
+from mash_client.controller import get_job_schema_by_cloud, add_job
 
 
 @click.group()
@@ -64,11 +63,7 @@ def add(context, dry_run, document):
         if dry_run:
             job_data['dry_run'] = True
 
-        result = handle_request_with_token(
-            config_data,
-            '/jobs/ec2/',
-            job_data
-        )
+        result = add_job(config_data, job_data, 'ec2')
 
         if 'msg' in result:
             echo_style(result['msg'], config_data['no_color'])

--- a/mash_client/cli/job/ec2.py
+++ b/mash_client/cli/job/ec2.py
@@ -101,7 +101,12 @@ def get_schema(context, output_style):
     """
     Get the an annotated json dictionary for a EC2 job.
     """
-    get_job_schema_by_cloud(context, output_style, 'ec2')
+    config_data = get_config(context.obj)
+
+    with handle_errors(config_data['log_level'], config_data['no_color']):
+        result = get_job_schema_by_cloud(config_data, output_style, 'ec2')
+
+    echo_dict(result, config_data['no_color'])
 
 
 ec2.add_command(add)

--- a/mash_client/cli/job/gce.py
+++ b/mash_client/cli/job/gce.py
@@ -28,9 +28,9 @@ from mash_client.cli_utils import (
     handle_errors,
     handle_request_with_token,
     echo_dict,
-    echo_style,
-    get_job_schema_by_cloud
+    echo_style
 )
+from mash_client.controller import get_job_schema_by_cloud
 
 
 @click.group()

--- a/mash_client/cli/job/gce.py
+++ b/mash_client/cli/job/gce.py
@@ -26,11 +26,10 @@ import json
 from mash_client.cli_utils import (
     get_config,
     handle_errors,
-    handle_request_with_token,
     echo_dict,
     echo_style
 )
-from mash_client.controller import get_job_schema_by_cloud
+from mash_client.controller import get_job_schema_by_cloud, add_job
 
 
 @click.group()
@@ -64,11 +63,7 @@ def add(context, dry_run, document):
         if dry_run:
             job_data['dry_run'] = True
 
-        result = handle_request_with_token(
-            config_data,
-            '/jobs/gce/',
-            job_data
-        )
+        result = add_job(config_data, job_data, 'gce')
 
         if 'msg' in result:
             echo_style(result['msg'], config_data['no_color'])

--- a/mash_client/cli/job/gce.py
+++ b/mash_client/cli/job/gce.py
@@ -101,7 +101,12 @@ def get_schema(context, output_style):
     """
     Get the an annotated json dictionary for a GCE job.
     """
-    get_job_schema_by_cloud(context, output_style, 'gce')
+    config_data = get_config(context.obj)
+
+    with handle_errors(config_data['log_level'], config_data['no_color']):
+        result = get_job_schema_by_cloud(config_data, output_style, 'gce')
+
+    echo_dict(result, config_data['no_color'])
 
 
 gce.add_command(add)

--- a/mash_client/cli/job/oci.py
+++ b/mash_client/cli/job/oci.py
@@ -28,9 +28,9 @@ from mash_client.cli_utils import (
     handle_errors,
     handle_request_with_token,
     echo_dict,
-    echo_style,
-    get_job_schema_by_cloud
+    echo_style
 )
+from mash_client.controller import get_job_schema_by_cloud
 
 
 @click.group()

--- a/mash_client/cli/job/oci.py
+++ b/mash_client/cli/job/oci.py
@@ -26,11 +26,10 @@ import json
 from mash_client.cli_utils import (
     get_config,
     handle_errors,
-    handle_request_with_token,
     echo_dict,
     echo_style
 )
-from mash_client.controller import get_job_schema_by_cloud
+from mash_client.controller import get_job_schema_by_cloud, add_job
 
 
 @click.group()
@@ -64,11 +63,7 @@ def add(context, dry_run, document):
         if dry_run:
             job_data['dry_run'] = True
 
-        result = handle_request_with_token(
-            config_data,
-            '/jobs/oci/',
-            job_data
-        )
+        result = add_job(config_data, job_data, 'oci')
 
         if 'msg' in result:
             echo_style(result['msg'], config_data['no_color'])

--- a/mash_client/cli/job/oci.py
+++ b/mash_client/cli/job/oci.py
@@ -101,7 +101,12 @@ def get_schema(context, output_style):
     """
     Get the an annotated json dictionary for a OCI job.
     """
-    get_job_schema_by_cloud(context, output_style, 'oci')
+    config_data = get_config(context.obj)
+
+    with handle_errors(config_data['log_level'], config_data['no_color']):
+        result = get_job_schema_by_cloud(config_data, output_style, 'oci')
+
+    echo_dict(result, config_data['no_color'])
 
 
 oci.add_command(add)

--- a/mash_client/cli_utils.py
+++ b/mash_client/cli_utils.py
@@ -435,15 +435,12 @@ def get_annotated_property(key, value, required):
     return annotated_value
 
 
-def get_job_schema_by_cloud(context, output_style, cloud):
-    config_data = get_config(context.obj)
-
-    with handle_errors(config_data['log_level'], config_data['no_color']):
-        result = handle_request(
-            config_data,
-            '/jobs/{cloud}/'.format(cloud=cloud),
-            action='get'
-        )
+def get_job_schema_by_cloud(config_data, output_style, cloud):
+    result = handle_request(
+        config_data,
+        '/jobs/{cloud}/'.format(cloud=cloud),
+        action='get'
+    )
 
     if output_style == 'json':
         json_result = {}
@@ -462,7 +459,7 @@ def get_job_schema_by_cloud(context, output_style, cloud):
 
         result = annotated_result
 
-    echo_dict(result, config_data['no_color'])
+    return result
 
 
 def parse_test_name(name):

--- a/mash_client/cli_utils.py
+++ b/mash_client/cli_utils.py
@@ -194,9 +194,10 @@ def handle_request(
     if not raise_for_status or response.status_code in (200, 201):
         return result
     elif 'errors' in result:
+        # Unknown properties have no keys
         raise MashClientException(
             '\n'.join(
-                '{key}: {val}'.format(key=key, val=val)
+                ': '.join(filter(None, [key, val]))
                 for key, val in result['errors'].items()
             )
         )

--- a/mash_client/cli_utils.py
+++ b/mash_client/cli_utils.py
@@ -433,42 +433,6 @@ def get_annotated_property(key, value, required):
     return annotated_value
 
 
-def get_job_schema_by_cloud(
-    config_data,
-    output_style,
-    cloud,
-    raise_for_status=True
-):
-    result = handle_request(
-        config_data,
-        '/jobs/{cloud}/'.format(cloud=cloud),
-        action='get',
-        raise_for_status=raise_for_status
-    )
-
-    if 'properties' not in result:
-        return result
-
-    if output_style == 'json':
-        json_result = {}
-        for key, value in result['properties'].items():
-            json_result[key] = '' if value['type'] == 'string' else None
-
-        result = json_result
-    elif output_style == 'annotated':
-        annotated_result = {}
-        for key, value in result['properties'].items():
-            annotated_result[key] = get_annotated_property(
-                key,
-                value,
-                result.get('required', tuple())
-            )
-
-        result = annotated_result
-
-    return result
-
-
 def parse_test_name(name):
     """Parse and return formatted pytest test name string."""
     test_class = None

--- a/mash_client/controller.py
+++ b/mash_client/controller.py
@@ -193,3 +193,12 @@ def get_job_test_results(config_data, job_id, raise_for_status=True):
         return {'msg': 'The job\'s test results are malformed.'}
 
     return result_data
+
+
+def add_job(config_data, job_data, cloud, raise_for_status=True):
+    return handle_request_with_token(
+        config_data,
+        '/jobs/{cloud}/'.format(cloud=cloud),
+        job_data,
+        raise_for_status=raise_for_status
+    )

--- a/mash_client/controller.py
+++ b/mash_client/controller.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+"""Helper methods for mash client endpoints."""
+
+# Copyright (c) 2020 SUSE LLC. All rights reserved.
+#
+# This file is part of mash_client. mash_client provides a command line
+# utility for interfacing with a MASH server.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from mash_client.cli_utils import handle_request, get_annotated_property
+
+
+def get_job_schema_by_cloud(
+    config_data,
+    output_style,
+    cloud,
+    raise_for_status=True
+):
+    result = handle_request(
+        config_data,
+        '/jobs/{cloud}/'.format(cloud=cloud),
+        action='get',
+        raise_for_status=raise_for_status
+    )
+
+    if 'properties' not in result:
+        return result
+
+    if output_style == 'json':
+        json_result = {}
+        for key, value in result['properties'].items():
+            json_result[key] = '' if value['type'] == 'string' else None
+
+        result = json_result
+    elif output_style == 'annotated':
+        annotated_result = {}
+        for key, value in result['properties'].items():
+            annotated_result[key] = get_annotated_property(
+                key,
+                value,
+                result.get('required', tuple())
+            )
+
+        result = annotated_result
+
+    return result


### PR DESCRIPTION
Add helper module to provide functions for routes that are accessible to the CLI and can be used as an SDK. Also, simplify the error handling for requests and add a raise_for_status flag which can be disabled when running as SDK to get the raw json message for all responses.

These changes omit all the cloud account routes which aren't required in automation tasks.