### PR TITLE
Require PyJWT < 2.0.0

### DIFF
--- a/mash_client/cli_utils.py
+++ b/mash_client/cli_utils.py
@@ -232,7 +232,11 @@ def handle_request_with_token(
     if 'access_token' not in tokens:
         refresh_token(config_data)
     else:
-        access_token = jwt.decode(tokens['access_token'], verify=False)
+        access_token = jwt.decode(
+            tokens['access_token'],
+            verify=False,
+            options={'verify_signature': False}
+        )
         now = int(time.time())
 
         if access_token.get('exp') and now >= access_token['exp']:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Click
 requests
 PyYAML
-PyJWT
+PyJWT<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Click
 requests
 PyYAML
-PyJWT<2.0.0
+PyJWT


### PR DESCRIPTION
Seems like PyJWT v2.0.0 broke the compatibility:

```
  File "main.py", line 102, in submit_mash_job
    result = add_job(config_data, job_data, framework)
  File "/home/ivan/work/img-release-manager/venv/lib64/python3.6/site-packages/mash_client-3.3.0-py3.6.egg/mash_client/controller.py", line 203, in add_job
    raise_for_status=raise_for_status
  File "/home/ivan/work/img-release-manager/venv/lib64/python3.6/site-packages/mash_client-3.3.0-py3.6.egg/mash_client/cli_utils.py", line 235, in handle_request_with_token
    access_token = jwt.decode(tokens['access_token'], verify=False)
  File "/home/ivan/work/img-release-manager/venv/lib64/python3.6/site-packages/PyJWT-2.0.0a1-py3.6.egg/jwt/api_jwt.py", line 92, in decode
    'It is required that you pass in a value for the "algorithms" argument when calling decode().'
```

It might make more sense to fix it to properly work with recent versions of PyJWT, but for now I've just required the stable version.