### PR TITLE
Add job list pagination options.

### DIFF
--- a/mash_client/cli/job/__init__.py
+++ b/mash_client/cli/job/__init__.py
@@ -57,15 +57,31 @@ def job():
 
 
 @click.command(name='list')
+@click.option(
+    '--page',
+    type=click.INT,
+    help='The page number of results to return.'
+)
+@click.option(
+    '--per-page',
+    type=click.INT,
+    help='The number of results to return per page.'
+)
 @click.pass_context
-def list_jobs(context):
+def list_jobs(context, per_page, page):
     """
     List all jobs in the MASH server pipeline.
     """
     config_data = get_config(context.obj)
 
     with handle_errors(config_data['log_level'], config_data['no_color']):
-        result = list_user_jobs(config_data)
+        kwargs = {}
+        if page:
+            kwargs['page'] = page
+        if per_page:
+            kwargs['per_page'] = per_page
+
+        result = list_user_jobs(config_data, **kwargs)
         echo_dict(result, config_data['no_color'])
 
 

--- a/mash_client/cli_utils.py
+++ b/mash_client/cli_utils.py
@@ -166,7 +166,7 @@ def handle_request(
     method = getattr(requests, action)
 
     headers = {}
-    if job_data:
+    if job_data is not None:
         headers = {'content-type': 'application/json'}
         job_data = json.dumps(job_data)
 

--- a/mash_client/controller.py
+++ b/mash_client/controller.py
@@ -141,10 +141,24 @@ def get_job(config_data, job_id, raise_for_status=True):
     )
 
 
-def list_user_jobs(config_data, raise_for_status=True):
+def list_user_jobs(
+    config_data,
+    raise_for_status=True,
+    page=None,
+    per_page=None
+):
+    job_data = {}
+
+    if page:
+        job_data['page'] = page
+
+    if per_page:
+        job_data['per_page'] = per_page
+
     return handle_request_with_token(
         config_data,
         '/jobs/',
+        job_data=job_data,
         action='get',
         raise_for_status=raise_for_status
     )


### PR DESCRIPTION
To the user job list route. By default the first page is returned with 10 results.

Fixes #77 