### PR TITLE
Fix test results parsing

### DIFF
--- a/mash_client/cli_utils.py
+++ b/mash_client/cli_utils.py
@@ -470,7 +470,7 @@ def echo_verbose_results(data, no_color):
         else:
             fg = 'red'
 
-        name = parse_test_name(test['name'])
+        name = parse_test_name(test['nodeid'])
         echo_style(
             '{} {}'.format(name, test['outcome'].upper()),
             no_color,

--- a/mash_client/controller.py
+++ b/mash_client/controller.py
@@ -203,7 +203,7 @@ def get_job_test_results(config_data, job_id, raise_for_status=True):
         return {'msg': 'The job has no test results.'}
 
     try:
-        result_data = json.loads(raw_test_results.replace('\'', '"'))
+        result_data = json.loads(raw_test_results)
     except json.decoder.JSONDecodeError:
         return {'msg': 'The job\'s test results are malformed.'}
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -17,17 +17,17 @@ test_results = {
     },
     'tests': [
         {
-            'name': 'test_soft_reboot',
+            'nodeid': 'test_soft_reboot',
             'outcome': 'failed',
             'test_index': 0
         },
         {
-            'name': 'test_sles_motd.py::test_sles_motd',
+            'nodeid': 'test_sles_motd.py::test_sles_motd',
             'outcome': 'passed',
             'test_index': 1
         },
         {
-            'name': 'test_sles_license.py::test_sles_license',
+            'nodeid': 'test_sles_license.py::test_sles_license',
             'outcome': 'skipped',
             'test_index': 2
         }


### PR DESCRIPTION
Output from mash no longer requires sanitization and name changed
to nodeid.