### PR TITLE
Add option to create refresh token with no expiry

### DIFF
--- a/mash_client/cli/auth/__init__.py
+++ b/mash_client/cli/auth/__init__.py
@@ -51,8 +51,14 @@ def auth():
     type=click.STRING,
     help='The email for the mash user (default taken from config).'
 )
+@click.option(
+    '--no-expiry',
+    is_flag=True,
+    help='Creates a refresh token with no expiration '
+         '(default expiry is 30 days).'
+)
 @click.pass_context
-def login(context, email):
+def login(context, email, no_expiry):
     """
     Handle mash user login.
     """
@@ -71,7 +77,12 @@ def login(context, email):
 
     with handle_errors(config_data['log_level'], config_data['no_color']):
         password = click.prompt('Enter password', type=str, hide_input=True)
-        result = login_with_pass(config_data, email, password)
+        result = login_with_pass(
+            config_data,
+            email,
+            password,
+            no_expiry=no_expiry
+        )
         echo_style(result['msg'], config_data['no_color'])
 
 

--- a/mash_client/controller.py
+++ b/mash_client/controller.py
@@ -68,8 +68,17 @@ def get_job_schema_by_cloud(
     return result
 
 
-def login_with_pass(config_data, email, password, raise_for_status=True):
+def login_with_pass(
+    config_data,
+    email,
+    password,
+    raise_for_status=True,
+    no_expiry=False
+):
     job_data = {'email': email, 'password': password}
+
+    if no_expiry:
+        job_data['no_expiry'] = True
 
     result = handle_request(
         config_data,

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -43,7 +43,7 @@ def test_request_handler(mock_send_header, mock_send_response, mock_end_hdrs):
     with raises(CodeReceivedException) as e:
         rh.do_GET()
 
-    assert(e.value.code == code)
+    assert (e.value.code == code)
     mock_send_response.assert_called_once_with(200)
     mock_send_header.assert_called_once_with('Content-type', 'text/html')
 


### PR DESCRIPTION
The --no-expiry option creates a refresh token at login with no expiration date. To cleanup the token it requires manual deletion.