### PR TITLE
Drop test results from info command

### DIFF
--- a/mash_client/cli/job/__init__.py
+++ b/mash_client/cli/job/__init__.py
@@ -120,6 +120,9 @@ def get(context, job_id, show_data):
         if not show_data:
             with suppress(KeyError):
                 del result['data']
+        elif 'test_results' in result['data']:
+            # Retrieved via `mash job test-results` command
+            del result['data']['test_results']
 
         echo_dict(result, config_data['no_color'])
 


### PR DESCRIPTION
The test results are available and parsed better using the `mash job test-results` command.