### PR TITLE
Add readthedocs config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+sphinx:
+  configuration: docs/source/conf.py
+formats:
+  - pdf
+  - epub
+python:
+  install:
+    - requirements: requirements-dev.txt


### PR DESCRIPTION
The config file is now required for successful build.